### PR TITLE
Retag commit sha image for release version tags

### DIFF
--- a/.github/workflows/galexie.yml
+++ b/.github/workflows/galexie.yml
@@ -2,7 +2,9 @@ name: Galexie
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release/**'
     tags: ['galexie-v*']
   pull_request:
 
@@ -36,57 +38,61 @@ jobs:
           sudo bash -c 'echo "deb https://apt.stellar.org focal unstable" > /etc/apt/sources.list.d/SDF-unstable.list'
           sudo apt-get update && sudo apt-get install -y stellar-core="$CAPTIVE_CORE_DEBIAN_PKG_VERSION"
           echo "Using stellar core version $(stellar-core version)"
-
       - name: Pull Quickstart image
         shell: bash
-        run: |
-          docker pull "$GALEXIE_INTEGRATION_TESTS_QUICKSTART_IMAGE"
-
+        run: docker pull "$GALEXIE_INTEGRATION_TESTS_QUICKSTART_IMAGE"
       - name: Pull LocalStack image (for S3)
         if: ${{ matrix.storage_type == 'S3' }}
         shell: bash
         run: docker pull localstack/localstack:${GALEXIE_INTEGRATION_TESTS_LOCALSTACK_IMAGE_TAG}
-
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           # For pull requests, build and test the PR head not a merge of the PR with the destination.
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-
       - name: Run tests - ${{ matrix.storage_type }} integration
-        run: |
-          go test -v -race -run "TestGalexie${{ matrix.storage_type }}TestSuite" ./test/...
-  publish-docker:
-    name: push docker image
+        run: go test -v -race -run "TestGalexie${{ matrix.storage_type }}TestSuite" ./test/...
+
+  publish-sha-tag-image:
+    name: Push sha tag container image
     needs: integration-test
-    if: github.event_name != 'pull_request'
+    if: ${{ github.event_name != 'pull_request' && github.ref_type != 'tag' }}
     runs-on: ubuntu-22.04
     env:
       # this is the version of core to be bundled with galaxie on image
       STELLAR_CORE_VERSION: 24.0.0-2802.0d7b4345d.focal
     steps:
-      - name: Set VERSION
-        if: github.ref_type == 'tag'
-        run: |
-          echo "VERSION=${GITHUB_REF_NAME#galexie-v}" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
-      - name: Build docker
-        run: make docker-build
-
-      # Push images
+      - uses: actions/checkout@v5
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Push version tag to DockerHub
+      - name: Build docker
+        run: make docker-build
+      - name: Push sha tag image to DockerHub
         run: make docker-push
 
+  publish-release-tag-image:
+    name: Push release tag container image
+    needs: integration-test
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set RELEASE_VERSION
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF_NAME#galexie-v}" >> $GITHUB_ENV
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Pull git sha tag image
+        run: make docker-pull
+      - name: Push release tag image
+        run: make docker-push-release
       - name: Push latest tag to DockerHub
-        if: ${{ (github.ref_type == 'tag') && (! contains(github.ref, '-rc')) }}
+        if: ${{ ! contains(github.ref, '-rc') }}
         run: make docker-push-latest
   
   complete:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 BUILD_DATE := $(shell date -u +%FT%TZ)
 VERSION ?= $(shell git rev-parse --short HEAD)
+RELEASE_VERSION ?= $(shell git describe --exact-match --tags)
 DOCKER_IMAGE := stellar/stellar-galexie
 
 docker-build:
@@ -38,8 +39,15 @@ docker-test-fake-gcs: docker-clean
 
 	$(MAKE) docker-clean
 
+docker-pull:
+	$(SUDO) docker pull $(DOCKER_IMAGE):$(VERSION)
+
 docker-push:
 	$(SUDO) docker push $(DOCKER_IMAGE):$(VERSION)
+
+docker-push-release:
+	$(SUDO) docker tag $(DOCKER_IMAGE):$(VERSION) $(DOCKER_IMAGE):$(RELEASE_VERSION)
+	$(SUDO) docker push $(DOCKER_IMAGE):$(RELEASE_VERSION)
 
 docker-push-latest:
 	$(SUDO) docker tag $(DOCKER_IMAGE):$(VERSION) $(DOCKER_IMAGE):latest


### PR DESCRIPTION

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Set up automatic image builds on release branches
Use branch git sha tagged images for retagging with release version tags

### Why

We want to be releasing images that are being tested in previous environments rather than rebuilding new images

https://github.com/stellar/ops/issues/4221

### Known limitations

[TODO or N/A]
