### PR TITLE
Migrate the stellar-core package repo to Jammy

### DIFF
--- a/.github/workflows/galexie.yml
+++ b/.github/workflows/galexie.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         storage_type: [ GCS, S3 ]
     env:
-      CAPTIVE_CORE_DEBIAN_PKG_VERSION: 24.1.0-2861.5a7035d49.focal
+      CAPTIVE_CORE_DEBIAN_PKG_VERSION: 24.1.0-2861.5a7035d49.jammy
       GALEXIE_INTEGRATION_TESTS_ENABLED: "true"
       GALEXIE_INTEGRATION_TESTS_CAPTIVE_CORE_BIN: /usr/bin/stellar-core
       # this pins to a version of quickstart:testing that has the same version as GALEXIE_INTEGRATION_TESTS_CAPTIVE_CORE_BIN
@@ -35,7 +35,7 @@ jobs:
           sudo apt-get remove -y libc++1-* libc++abi1-* || true
 
           sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
-          sudo bash -c 'echo "deb https://apt.stellar.org focal unstable" > /etc/apt/sources.list.d/SDF-unstable.list'
+          sudo bash -c 'echo "deb https://apt.stellar.org jammy unstable" > /etc/apt/sources.list.d/SDF-unstable.list'
           sudo apt-get update && sudo apt-get install -y stellar-core="$CAPTIVE_CORE_DEBIAN_PKG_VERSION"
           echo "Using stellar core version $(stellar-core version)"
       - name: Pull Quickstart image
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       # this is the version of core to be bundled with galaxie on image
-      STELLAR_CORE_VERSION: 24.1.0-2861.5a7035d49.focal
+      STELLAR_CORE_VERSION: 24.1.0-2861.5a7035d49.jammy
     steps:
       - uses: actions/checkout@v5
       - name: Login to DockerHub

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,8 +21,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 # ca-certificates are required to make tls connections
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl wget gnupg apt-utils
 RUN wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true apt-key add -
-RUN echo "deb https://apt.stellar.org focal stable" >/etc/apt/sources.list.d/SDF.list
-RUN echo "deb https://apt.stellar.org focal unstable" >/etc/apt/sources.list.d/SDF-unstable.list
+RUN echo "deb https://apt.stellar.org jammy stable" >/etc/apt/sources.list.d/SDF.list
+RUN echo "deb https://apt.stellar.org jammy unstable" >/etc/apt/sources.list.d/SDF-unstable.list
 RUN apt-get update && apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
 RUN apt-get clean
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Migrate apt repository for stellar-core package from Focal to Jammy.

### Why
stellar-core is dropping support for the Focal.

### Known limitations
N/A