### PR TITLE
Add version command to CLI

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -150,12 +150,20 @@ func DefineCommands() *cobra.Command {
 			return galexieCmdRunner(settings)
 		},
 	}
+	var versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print the version of galexie",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintf(cmd.OutOrStdout(), "stellar-galexie %s\n", galexie.Version())
+		},
+	}
 
 	rootCmd.AddCommand(scanAndFillCmd)
 	rootCmd.AddCommand(appendCmd)
 	rootCmd.AddCommand(ReplaceCmd)
 	rootCmd.AddCommand(detectGapsCmd)
 	rootCmd.AddCommand(loadTestCmd)
+	rootCmd.AddCommand(versionCmd)
 
 	commonFlags := pflag.NewFlagSet("common_flags", pflag.ExitOnError)
 	commonFlags.Uint32P("start", "s", 0, "Starting ledger (inclusive), must be set to a value greater than 1")

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	galexie "github.com/stellar/stellar-galexie/internal"
 )
@@ -227,4 +228,18 @@ func TestFlagsOutput(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVersionCommand(t *testing.T) {
+	rootCmd := DefineCommands()
+	rootCmd.SetArgs([]string{"version"})
+
+	var outWriter bytes.Buffer
+	rootCmd.SetOut(&outWriter)
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	output := outWriter.String()
+	assert.Equal(t, "stellar-galexie "+galexie.Version()+"\n", output)
 }

--- a/internal/app.go
+++ b/internal/app.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"runtime/debug"
 	"sync"
 	"syscall"
 	"time"
@@ -48,6 +49,21 @@ var (
 	logger  = log.New().WithField("service", nameSpace)
 	version = "develop"
 )
+
+func init() {
+	if version == "develop" {
+		// Fallback to build info version if not set via ldflags. This preserves
+		// the version when installed via `go install`, which embeds version info.
+		// Ignore "(devel)" which Go returns for local builds to preserve "develop".
+		if bi, ok := debug.ReadBuildInfo(); ok && bi.Main.Version != "" && bi.Main.Version != "(devel)" {
+			version = bi.Main.Version
+		}
+	}
+}
+
+func Version() string {
+	return version
+}
 
 func NewDataAlreadyExportedError(Start uint32, End uint32) *DataAlreadyExportedError {
 	return &DataAlreadyExportedError{


### PR DESCRIPTION
### What
Add a `version` command to the galexie CLI that prints the application version. Fall back to build info version when installed via `go install github.com/stellar/stellar-galexie@latest` where no version is set via ldflags.

### Examples
#### Built with ldflags
Install galexie with:
```
$ go install -ldflags=-X=github.com/stellar/stellar-galexie/internal.version=$(git rev-parse --short HEAD)
```
Then run the version subcommand:
```
$ stellar-galexie version
stellar-galexie 058eccb1
```

#### Built with module info
Install galexie with:
```
go install github.com/stellar/stellar-galexie@v0.0.0-20260106141926-058eccb1ad05
```
Then run the version subcommand:
```
$ stellar-galexie version
stellar-galexie v0.0.0-20260106141926-058eccb1ad05
```

### Why
I was using galexie and wanted to know what version of galexie I was using but couldn't see a command.

I noticed #26 was opened but looks like it has had no activity since last year so figured this was okay to take.

Close https://github.com/stellar/stellar-galexie/issues/26