### PR TITLE
Tighten release tag filter in galexie workflow

### DIFF
--- a/.github/workflows/galexie.yml
+++ b/.github/workflows/galexie.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - main
       - 'release/**'
-    tags: ['galexie-v*']
+    tags:
+      - 'galexie-v[0-9]+.[0-9]+.[0-9]+'
+      - 'galexie-v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- Replace the loose `galexie-v*` tag glob in `.github/workflows/galexie.yml` with two explicit patterns matching `galexie-vX.Y.Z` and `galexie-vX.Y.Z-rcN`.

## Why
The previous glob accepted arbitrary suffixes, including ones containing shell metacharacters. `RELEASE_VERSION` flows from the tag (`GITHUB_REF_NAME`) into `$GITHUB_ENV` and then through `make docker-push-release`, where it lands unquoted in `docker tag` / `docker push` shell commands. Constraining the filter at the trigger layer prevents non-conforming tags from ever starting a release build.

## Test plan
- [x] Regex sanity-check on the equivalent pattern accepts `galexie-v1.2.3`, `galexie-v10.20.30`, `galexie-v1.2.3-rc1`, `galexie-v1.2.3-rc99`; rejects `galexie-v1.2`, `galexie-vX.Y.Z`, `galexie-v1.2.3-beta`, `galexie-v1.2.3-rc`, `galexie-v1.2.3-rcX`, `galexie-v1.2.3.4`, `galexie-v\$(curl evil)`, `galexie-v1.2.3 ; rm -rf /`.
- [x] `act push --dryrun -W .github/workflows/galexie.yml` parses the workflow cleanly with the new filter syntax.
- [ ] End-to-end confirmation: push a throwaway tag in a sandbox to verify GitHub honors the new filter (recommend before relying on it).